### PR TITLE
Refactor Makefile

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -32,7 +32,7 @@ blocks:
       jobs:
         - name: Run Snyk
           commands:
-            - make docker/snyk
+            - make test/snyk
 
 promotions:
   - name: Docker Hub


### PR DESCRIPTION
- move `help` target to the end for better readability (add a `default` target)
- remove sorting targets in help
- adjust sempahore scripts for new targets
- refactor `.PHONY` to be defined at the target and more git-friendly this way
- rename snyk to `test/snyk`