### PR TITLE
Set HOME environment variable to /tmp in entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,10 @@ RUN wget \
     sha256sum -cs packer_${PACKER_VERSION}_SHA256SUMS && \
     unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /usr/local/bin
 
+COPY scripts/entrypoint.sh /
+
 WORKDIR /app/src
 
-CMD echo "You must call terraform, tflint or packer  commands: e.g. `docker run mineiros/build-tools terraform --version`"
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["echo", "You must call terraform, tflint or packer  commands: e.g. `docker run mineiros/build-tools terraform --version`"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+HOME=/tmp
+
+exec "${@}"


### PR DESCRIPTION
this enables to run the conatiner with any user id.

pre-commit creates $HOME/.cache files and so eny user id needs write
access to $HOME