### PR TITLE
upgrade packer to version 1.5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG TFLINT_CHECKSUM=checksums.txt
 ARG TFLINT_CHECKSUM_URL=https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/${TFLINT_CHECKSUM}
 
 # Packer https://www.packer.io/
-ARG PACKER_VERSION=1.5.5
+ARG PACKER_VERSION=1.5.6
 ARG PACKER_ARCHIVE=packer_${PACKER_VERSION}_linux_amd64.zip
 ARG PACKER_URL=https://releases.hashicorp.com/packer/${PACKER_VERSION}/${PACKER_ARCHIVE}
 ARG PACKER_CHECKSUM=packer_${PACKER_VERSION}_SHA256SUMS


### PR DESCRIPTION
This PR bumps packer to version 1.5.6. 

I feel that we should automate this process instead of manually bumping versions. Any idea how we can achieve that @mariux ?