### PR TITLE
Refactor and speed up repeated builds

### DIFF
--- a/.semaphore/docker-hub.yml
+++ b/.semaphore/docker-hub.yml
@@ -15,7 +15,8 @@ blocks:
           - export DOCKER_IMAGE_TAG=${SEMAPHORE_GIT_TAG_NAME:-${SEMAPHORE_GIT_SHA}}
           - echo DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}
           - echo SEMAPHORE_GIT_SHA=${SEMAPHORE_GIT_SHA}
-          - make semaphore/restore
+          - cache restore ${SEMAPHORE_GIT_SHA}
+          - make docker/load
           - make docker/login
       jobs:
         - name: "Push Image"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,6 +30,9 @@ blocks:
                 make docker/save ;
                 cache store ${SEMAPHORE_GIT_SHA} ${CACHE_BASE_DIR} ;
               fi
+        - name: Check Versions
+          commands:
+            - make check/updates
 
   - name: Forensics
     dependencies: [ "Build" ]

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -47,6 +47,9 @@ blocks:
         - name: Run Snyk
           commands:
             - make test/snyk
+        - name: Run Tools
+          commands:
+            - make test/execute-tools
 
 promotions:
   - name: Docker Hub

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6,15 +6,21 @@ agent:
     os_image: ubuntu1804
 
 global_job_config:
+  env_vars:
+    - name: CACHE_BASE_DIR
+      value: cache
   prologue:
     commands:
       - checkout --use-cache
       - export DOCKER_IMAGE_TAG=${SEMAPHORE_GIT_TAG_NAME:-${SEMAPHORE_GIT_SHA}}
+      - echo CACHE_BASE_DIR=${CACHE_BASE_DIR}
       - echo DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}
       - echo SEMAPHORE_GIT_SHA=${SEMAPHORE_GIT_SHA}
+      - echo SEMAPHORE_GIT_TAG_NAME=${SEMAPHORE_GIT_TAG_NAME}
 
 blocks:
   - name: Build
+    dependencies: []
     task:
       jobs:
         - name: Build Docker Image
@@ -22,10 +28,11 @@ blocks:
             - if ! cache has_key ${SEMAPHORE_GIT_SHA} ; then
                 make docker/build ;
                 make docker/save ;
-                cache store ${SEMAPHORE_GIT_SHA} cache ;
+                cache store ${SEMAPHORE_GIT_SHA} ${CACHE_BASE_DIR} ;
               fi
 
   - name: Forensics
+    dependencies: [ "Build" ]
     task:
       secrets:
         - name: SNYK_CREDENTIALS

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,8 +19,11 @@ blocks:
       jobs:
         - name: Build Docker Image
           commands:
-            - make docker/build
-            - make semaphore/store
+            - if ! cache has_key ${SEMAPHORE_GIT_SHA} ; then
+                make docker/build ;
+                make docker/save ;
+                cache store ${SEMAPHORE_GIT_SHA} cache ;
+              fi
 
   - name: Forensics
     task:
@@ -28,7 +31,8 @@ blocks:
         - name: SNYK_CREDENTIALS
       prologue:
         commands:
-          - make semaphore/restore
+          - cache restore ${SEMAPHORE_GIT_SHA}
+          - make docker/load
       jobs:
         - name: Run Snyk
           commands:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ ARG PACKER_URL=https://releases.hashicorp.com/packer/${PACKER_VERSION}/${PACKER_
 ARG PACKER_CHECKSUM=packer_${PACKER_VERSION}_SHA256SUMS
 ARG PACKER_CHECKSUM_URL=https://releases.hashicorp.com/packer/${PACKER_VERSION}/${PACKER_CHECKSUM}
 
+# pre-commit
+ARG PRECOMMIT_VERSION
+
 # If TF_IN_AUTOMATION is set to any non-empty value, Terraform adjusts its output to avoid suggesting specific commands
 # to run next. This can make the output more consistent and less confusing in workflows where users don't directly
 # execute Terraform commands, like in CI systems or other wrapping applications.
@@ -38,7 +41,7 @@ ENV CGO_ENABLED=0
 RUN apk add --update docker bash git openrc openssh openssl python3
 
 # Install pre-commit framework
-RUN pip3 install pre-commit
+RUN pip3 install pre-commit==$PRECOMMIT_VERSION
 
 # Download Terraform, verify checksum and install to bin dir
 RUN wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,21 +3,21 @@ FROM golang:1.14.2-alpine3.11
 LABEL maintainer="The Mineiros.io Team <hello@mineiros.io>"
 
 # Terraform https://www.terraform.io/
-ARG TERRAFORM_VERSION=0.12.24
+ARG TERRAFORM_VERSION
 ARG TERRAFORM_ARCHIVE=terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 ARG TERRAFORM_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_ARCHIVE}
 ARG TERRAFORM_CHECKSUM=terraform_${TERRAFORM_VERSION}_SHA256SUMS
 ARG TERRAFORM_CHECKSUM_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_CHECKSUM}
 
 # TFLint https://github.com/terraform-linters/tflint
-ARG TFLINT_VERSION=v0.15.3
+ARG TFLINT_VERSION
 ARG TFLINT_ARCHIVE=tflint_linux_amd64.zip
-ARG TFLINT_URL=https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/${TFLINT_ARCHIVE}
+ARG TFLINT_URL=https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/${TFLINT_ARCHIVE}
 ARG TFLINT_CHECKSUM=checksums.txt
-ARG TFLINT_CHECKSUM_URL=https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/${TFLINT_CHECKSUM}
+ARG TFLINT_CHECKSUM_URL=https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/${TFLINT_CHECKSUM}
 
 # Packer https://www.packer.io/
-ARG PACKER_VERSION=1.5.6
+ARG PACKER_VERSION
 ARG PACKER_ARCHIVE=packer_${PACKER_VERSION}_linux_amd64.zip
 ARG PACKER_URL=https://releases.hashicorp.com/packer/${PACKER_VERSION}/${PACKER_ARCHIVE}
 ARG PACKER_CHECKSUM=packer_${PACKER_VERSION}_SHA256SUMS

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,15 @@ endif
 TERRAFORM_VERSION = 0.12.24
 TFLINT_VERSION = 0.15.3
 PACKER_VERSION = 1.5.6
+PRECOMMIT_VERSION = 2.4.0
 
 .PHONY: default
 default: help
 
 .PHONY: check/updates
+
 ## check for updates
+check/updates: PRECOMMIT_LATEST=$(shell curl -s "https://api.github.com/repos/pre-commit/pre-commit/releases/latest" | jq -r -M '.tag_name' | sed -e 's/^v//')
 check/updates: TFLINT_LATEST=$(shell curl -s "https://api.github.com/repos/terraform-linters/tflint/releases/latest" | jq -r -M '.tag_name' | sed -e 's/^v//')
 check/updates: PACKER_LATEST=$(shell curl -s https://checkpoint-api.hashicorp.com/v1/check/packer | jq -r -M '.current_version')
 check/updates: TERRAFORM_LATEST = $(shell curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version')
@@ -43,10 +46,15 @@ check/updates:
 	else \
 	  echo "${GREEN}packer ${PACKER_VERSION} - packer is up to date.${RESET}" ; \
 	fi
-	@if [ "v${TFLINT_VERSION}" != "${TFLINT_LATEST}" ] ; then \
+	@if [ "${TFLINT_VERSION}" != "${TFLINT_LATEST}" ] ; then \
 	  echo "${RED}tflint ${TFLINT_VERSION}${YELLOW} - update available to tflint ${TFLINT_LATEST}${RESET}" ; \
 	else \
 	  echo "${GREEN}tflint ${TFLINT_VERSION} - tflint is up to date.${RESET}" ; \
+	fi
+	@if [ "${PRECOMMIT_VERSION}" != "${PRECOMMIT_LATEST}" ] ; then \
+	  echo "${RED}pre-commit ${PRECOMMIT_VERSION}${YELLOW} - update available to pre-commit ${PRECOMMIT_LATEST}${RESET}" ; \
+	else \
+	  echo "${GREEN}pre-commit ${PRECOMMIT_VERSION} - pre-commit is up to date.${RESET}" ; \
 	fi
 
 .PHONY: docker/build
@@ -56,6 +64,7 @@ docker/build:
 	  --build-arg TERRAFORM_VERSION=${TERRAFORM_VERSION} \
 	  --build-arg PACKER_VERSION=${PACKER_VERSION} \
 	  --build-arg TFLINT_VERSION=${TFLINT_VERSION} \
+	  --build-arg PRECOMMIT_VERSION=${PRECOMMIT_VERSION} \
 	  -t ${DOCKER_IMAGE} . | cat
 
 .PHONY: docker/tag

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,21 @@ CACHE_FILE ?= ${CACHE_BASE_DIR}/${DOCKER_HUB_REPO}/${DOCKER_IMAGE_TAG}.tar
 GREEN := $(shell tput -Txterm setaf 2)
 RESET := $(shell tput -Txterm sgr0)
 
+TERRAFORM_VERSION = 0.12.24
+TFLINT_VERSION = 0.15.3
+PACKER_VERSION = 1.5.6
+
 .PHONY: default
 default: help
 
 .PHONY: docker/build
 ## Build the docker image
 docker/build:
-	docker build -t ${DOCKER_IMAGE} . | cat
+	docker build \
+	  --build-arg TERRAFORM_VERSION=${TERRAFORM_VERSION} \
+	  --build-arg PACKER_VERSION=${PACKER_VERSION} \
+	  --build-arg TFLINT_VERSION=${TFLINT_VERSION} \
+	  -t ${DOCKER_IMAGE} . | cat
 
 .PHONY: docker/tag
 ## Create a new tag

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Set default shell to bash
-SHELL := /bin/bash
+SHELL := /bin/bash -o pipefail
 
 TERRAFORM_VERSION = 0.12.25
 TFLINT_VERSION = 0.16.0

--- a/Makefile
+++ b/Makefile
@@ -61,18 +61,16 @@ docker/push:
 	if [[ "${DOCKER_IMAGE_TAG}" == v[0-9]* ]] ; then docker push ${DOCKER_HUB_REPO}:latest | cat ; fi
 	docker push ${DOCKER_HUB_REPO}:${DOCKER_IMAGE_TAG} | cat
 
-.PHONY: semaphore/store
+.PHONY: docker/save
 ## Save the docker image to disk
-semaphore/store:
-	docker save ${DOCKER_HUB_REPO}:${DOCKER_IMAGE_TAG} > docker-image.tar
-	cache store ${DOCKER_IMAGE_TAG} docker-image.tar
-	rm -f docker-image.tar
+docker/save:
+	mkdir -p cache/${DOCKER_HUB_REPO}
+	docker save ${DOCKER_HUB_REPO}:${DOCKER_IMAGE_TAG} > cache/${DOCKER_HUB_REPO}/${DOCKER_IMAGE_TAG}.tar
 
-.PHONY: semaphore/restore
+.PHONY: docker/load
 ## Load saved image
-semaphore/restore:
-	cache restore ${DOCKER_IMAGE_TAG}
-	docker load < docker-image.tar | cat
+docker/load:
+	docker load < cache/${DOCKER_HUB_REPO}/${DOCKER_IMAGE_TAG}.tar | cat
 
 .PHONY: test/snyk
 ## Check for vulnerabilities with Snyk.io ( requires the environment variables "SNYK_TOKEN" and "USER_ID" to be set )

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,28 @@ PACKER_VERSION = 1.5.6
 .PHONY: default
 default: help
 
+.PHONY: check/updates
+## check for updates
+check/updates: TFLINT_LATEST=$(shell curl -s "https://api.github.com/repos/terraform-linters/tflint/releases/latest" | jq -r -M '.tag_name' | sed -e 's/^v//')
+check/updates: PACKER_LATEST=$(shell curl -s https://checkpoint-api.hashicorp.com/v1/check/packer | jq -r -M '.current_version')
+check/updates: TERRAFORM_LATEST = $(shell curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version')
+check/updates:
+	@if [ "${TERRAFORM_VERSION}" != "${TERRAFORM_LATEST}" ] ; then \
+	  echo "${RED}terraform ${TERRAFORM_VERSION}${YELLOW} - update available to terraform ${TERRAFORM_LATEST}${RESET}" ; \
+	else \
+	  echo "${GREEN}terraform ${TERRAFORM_VERSION} - terraform is up to date.${RESET}" ; \
+	fi
+	@if [ "${PACKER_VERSION}" != "${PACKER_LATEST}" ] ; then \
+	  echo "${RED}packer ${PACKER_VERSION}${YELLOW} - update available to packer ${PACKER_LATEST}${RESET}" ; \
+	else \
+	  echo "${GREEN}packer ${PACKER_VERSION} - packer is up to date.${RESET}" ; \
+	fi
+	@if [ "v${TFLINT_VERSION}" != "${TFLINT_LATEST}" ] ; then \
+	  echo "${RED}tflint ${TFLINT_VERSION}${YELLOW} - update available to tflint ${TFLINT_LATEST}${RESET}" ; \
+	else \
+	  echo "${GREEN}tflint ${TFLINT_VERSION} - tflint is up to date.${RESET}" ; \
+	fi
+
 .PHONY: docker/build
 ## Build the docker image
 docker/build:

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,12 @@ SNYK_CLI_DOCKER_IMAGE ?= snyk/snyk-cli:1.305.1-docker
 CACHE_BASE_DIR ?= cache
 CACHE_FILE ?= ${CACHE_BASE_DIR}/${DOCKER_HUB_REPO}/${DOCKER_IMAGE_TAG}.tar
 
-GREEN := $(shell tput -Txterm setaf 2)
-RESET := $(shell tput -Txterm sgr0)
+ifndef NOCOLOR
+	RED    := $(shell tput -Txterm setaf 1)
+	GREEN  := $(shell tput -Txterm setaf 2)
+	YELLOW := $(shell tput -Txterm setaf 3)
+	RESET  := $(shell tput -Txterm sgr0)
+endif
 
 TERRAFORM_VERSION = 0.12.24
 TFLINT_VERSION = 0.15.3

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,16 @@ test/snyk:
 		-v ${DOCKER_SOCKET}:/var/run/docker.sock \
 		${SNYK_CLI_DOCKER_IMAGE} test --docker ${DOCKER_IMAGE} --file=Dockerfile | cat
 
+.PHONY: test/snyk
+## Check if all build tools execute without issues
+test/execute-tools:
+	docker run --rm ${DOCKER_IMAGE} terraform --version
+	docker run --rm ${DOCKER_IMAGE} packer --version
+	docker run --rm ${DOCKER_IMAGE} tflint --version
+	docker run --rm ${DOCKER_IMAGE} pre-commit --version
+	docker run --rm ${DOCKER_IMAGE} golint
+	docker run --rm ${DOCKER_IMAGE} goimports
+
 .PHONY: help
 ## Display help for all targets
 help:
@@ -115,7 +125,7 @@ help:
 				msg = substr(lastLine, RSTART + 3, RLENGTH); \
 				gsub("\\\\", "", cmd); \
 				gsub(":+$$", "", cmd); \
-				printf "  ${GREEN}make %-15s${RESET} %s\n", cmd, msg; \
+				printf "  ${GREEN}make %-20s${RESET} %s\n", cmd, msg; \
 			} \
 	} \
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 # Set default shell to bash
 SHELL := /bin/bash
 
+TERRAFORM_VERSION = 0.12.25
+TFLINT_VERSION = 0.16.0
+PACKER_VERSION = 1.5.6
+PRECOMMIT_VERSION = 2.4.0
+
 DOCKER_HUB_REPO ?= mineiros/build-tools
 DOCKER_IMAGE_TAG ?= build
 DOCKER_IMAGE ?= ${DOCKER_HUB_REPO}:${DOCKER_IMAGE_TAG}
@@ -19,11 +24,6 @@ ifndef NOCOLOR
 	YELLOW := $(shell tput -Txterm setaf 3)
 	RESET  := $(shell tput -Txterm sgr0)
 endif
-
-TERRAFORM_VERSION = 0.12.24
-TFLINT_VERSION = 0.15.3
-PACKER_VERSION = 1.5.6
-PRECOMMIT_VERSION = 2.4.0
 
 .PHONY: default
 default: help


### PR DESCRIPTION
- remove semaphore/ targets again as suggested by @soerenmartius 
- simplify makefile variables
- on repeated builds load container from cache
- check versions on builds
- add test to actually execute each build tool
- add NOCOLOR option ot make
- update terraform to 0.12.25
- update tflint to 0.16.0
- install explicit version of pre-commits 2.4.0

needs release bump to 0.3.0 due to update in tflint from 0.15.x to 0.16.0

