### PR TITLE
Add Examples to README.md

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,5 +4,4 @@ repos:
     hooks:
       - id: phony-targets
       - id: shellcheck
-      - id: phony-targets
       - id: markdown-link-check

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,4 +92,4 @@ WORKDIR /app/src
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["echo", "You must call terraform, tflint or packer  commands: e.g. `docker run mineiros/build-tools terraform --version`"]
+CMD ["echo", "You must call terraform, tflint or packer commands: e.g. `docker run mineiros/build-tools terraform --version`"]


### PR DESCRIPTION
Add some examples that explain how to use the build-tools repository to the `README.md`
In addition to the added examples, the `README.md` now comes an overview of all installed technologies and linters also.