### PR TITLE
Remove redundant linters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Remove `goimports`, `golint` and `revive` since those linters are handled
+  through `golangci-lint` and therefore they are redundant.
+
 ## [0.13.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0]
+
 ### Breaking Changes
 
 - Remove `goimports`, `golint` and `revive` since those linters are handled
@@ -352,11 +354,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- markdown-link-check-disable -->
 
-[unreleased]: https://github.com/mineiros-io/build-tools/compare/v0.13.0...HEAD
-[0.13.0]: https://github.com/mineiros-io/build-tools/compare/v0.12.1...v0.13.0
+[unreleased]: https://github.com/mineiros-io/build-tools/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/mineiros-io/build-tools/compare/v0.13.0...v0.14.0
 
 <!-- markdown-link-check-enable -->
 
+[0.13.0]: https://github.com/mineiros-io/build-tools/compare/v0.12.1...v0.13.0
 [0.12.0]: https://github.com/mineiros-io/build-tools/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/mineiros-io/build-tools/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/mineiros-io/build-tools/compare/v0.10.0...v0.10.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,12 +86,6 @@ RUN wget \
     unzip $TFLINT_ARCHIVE -d /usr/local/bin && \
     rm -f $TFLINT_ARCHIVE $TFLINT_CHECKSUM
 
-# Install Go linter
-RUN go get -u \
-    golang.org/x/lint/golint \
-    github.com/mgechev/revive \
-    golang.org/x/tools/cmd/goimports
-
 # Install golangci-lint
 # Golangci_lint suggests to install the binary through the install script rather than `go get`.
 # For infos please see https://golangci-lint.run/usage/install/#ci-installation

--- a/Makefile
+++ b/Makefile
@@ -173,9 +173,7 @@ test/execute-tools:
 	docker run --rm ${BUILD_IMAGE} tflint --version
 	docker run --rm ${BUILD_IMAGE} pre-commit --version
 	docker run --rm ${BUILD_IMAGE} checkov --version
-	docker run --rm ${BUILD_IMAGE} golint
-	docker run --rm ${BUILD_IMAGE} revive --version
-	docker run --rm ${BUILD_IMAGE} goimports
+	docker run --rm ${BUILD_IMAGE} golangci-lint --version
 
 ## Display help for all targets
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -52,10 +52,7 @@ Currently, we are installing the following dependencies:
 In addition to the above listed technologies, build-tools ships with some
 pre-installed linters, that help you to ensure code quality and standards:
 
-- [(DEPRECATED) Golint](https://github.com/golang/lint)
-- [Revive](https://github.com/mgechev/revive)
 - [golangci-lint](https://github.com/golangci/golangci-lint)
-- [Goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)
 - [TFLint](https://github.com/terraform-linters/tflint)
 - [markdown-link-check](https://github.com/tcort/markdown-link-check)
 


### PR DESCRIPTION
- refactor!: remove golint, revive and goimport linters since they are being handled through golangci-lint
- chore: prepare v0.14.0 release
